### PR TITLE
Enable Contract Verification on Etherscan and Blockscout

### DIFF
--- a/dictionaries/names.txt
+++ b/dictionaries/names.txt
@@ -16,6 +16,3 @@ stebaiev
 vadim
 yavorsky
 blockscout
-skalenodes
-holesky
-hoodi

--- a/dictionaries/names.txt
+++ b/dictionaries/names.txt
@@ -15,3 +15,7 @@ payvint
 stebaiev
 vadim
 yavorsky
+blockscout
+skalenodes
+holesky
+hoodi

--- a/dictionaries/solidity.txt
+++ b/dictionaries/solidity.txt
@@ -7,4 +7,4 @@ selfdestruct
 staticcall
 struct
 abicoder
-escan
+

--- a/dictionaries/solidity.txt
+++ b/dictionaries/solidity.txt
@@ -7,3 +7,4 @@ selfdestruct
 staticcall
 struct
 abicoder
+escan

--- a/dictionaries/solidity.txt
+++ b/dictionaries/solidity.txt
@@ -7,4 +7,3 @@ selfdestruct
 staticcall
 struct
 abicoder
-

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@openzeppelin/hardhat-upgrades": "^3.1.1",
     "@openzeppelin/upgrades-core": "^1.27.1",
     "@types/mocha": "^9.1.0",
-    "ethers": "6.13.5",
     "hardhat": "^2.9.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
   },
   "peerDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.0",
-    "@nomicfoundation/hardhat-verify": "^2.0.0",
+    "@nomicfoundation/hardhat-verify": "^2.0.13",
     "@openzeppelin/hardhat-upgrades": "^3.1.1",
     "@openzeppelin/upgrades-core": "^1.27.1",
     "@types/mocha": "^9.1.0",
-    "ethers": "^6.13.4",
+    "ethers": "6.13.5",
     "hardhat": "^2.9.9"
   }
 }

--- a/src/contractVerifier.ts
+++ b/src/contractVerifier.ts
@@ -1,0 +1,107 @@
+import {
+    VerificationTarget,
+    getVerifyParameters,
+    isVerifiedOnBlockscout
+} from "./verification";
+import {Etherscan} from "@nomicfoundation/hardhat-verify/etherscan";
+import chalk from "chalk";
+
+export class ContractVerifier {
+    private readonly contractName: string;
+    private readonly contractAddress: string;
+    private readonly apiURL: string;
+    private readonly browserURL: string;
+    private readonly isEtherscan: boolean;
+    private readonly escan: Etherscan;
+
+    constructor(target: VerificationTarget) {
+        this.contractName = target.contractName;
+        this.contractAddress = target.contractAddress;
+        this.apiURL = target.explorerUrls.apiURL;
+        this.browserURL = target.explorerUrls.browserURL;
+        this.isEtherscan = Boolean(target.isEtherscan);
+        this.escan = new Etherscan(
+            process.env.ETHERSCAN ?? "",
+            this.apiURL,
+            this.browserURL
+        );
+    }
+
+    private async isAlreadyVerified(): Promise<boolean> {
+        let verified = false;
+
+        if (this.isEtherscan) {
+            verified = await this.escan.isVerified(this.contractAddress);
+        }
+        if (!verified) {
+            verified = await isVerifiedOnBlockscout(
+                this.apiURL,
+                this.contractAddress
+            );
+        }
+        if (verified) {
+            console.log(
+                `${this.contractName} is already verified on: ${this.escan.getContractUrl(
+                    this.contractAddress
+                )}`
+            );
+        }
+        return verified;
+    }
+
+    private async submitVerification(params: {
+        solcInputJson: string;
+        fullContractName: string;
+        compilerVersion: string;
+    }): Promise<string | null> {
+        try {
+            const res = await this.escan.verify(
+                this.contractAddress,
+                params.solcInputJson,
+                params.fullContractName,
+                params.compilerVersion,
+                "0x"
+            );
+            return res.message;
+        } catch (error) {
+            console.log(
+                chalk.yellow(
+                    `Verification attempt for ${this.contractName} failed with error: ${error}`
+                )
+            );
+            return null;
+        }
+    }
+
+    private async checkVerificationStatus(guid: string): Promise<boolean> {
+        const status = await this.escan.getVerificationStatus(guid);
+
+        if (status.isFailure()) {
+            console.log(
+                chalk.red(`Failed to verify contract ${this.contractName}`)
+            );
+            return false;
+        }
+
+        console.log(
+            `${this.contractName} is successfully verified on: ${this.escan.getContractUrl(
+                this.contractAddress
+            )}`
+        );
+        return true;
+    }
+
+    public async attempt(): Promise<boolean> {
+        if (await this.isAlreadyVerified()) {
+            return true;
+        }
+
+        const params = await getVerifyParameters(this.contractName);
+        const guid = await this.submitVerification(params);
+        if (!guid) {
+            return false;
+        }
+
+        return this.checkVerificationStatus(guid);
+    }
+}

--- a/src/contractVerifier.ts
+++ b/src/contractVerifier.ts
@@ -12,7 +12,7 @@ export class ContractVerifier {
     private readonly apiURL: string;
     private readonly browserURL: string;
     private readonly isEtherscan: boolean;
-    private readonly escan: Etherscan;
+    private readonly etherscan: Etherscan;
 
     constructor(target: VerificationTarget) {
         this.contractName = target.contractName;
@@ -20,7 +20,7 @@ export class ContractVerifier {
         this.apiURL = target.explorerUrls.apiURL;
         this.browserURL = target.explorerUrls.browserURL;
         this.isEtherscan = Boolean(target.isEtherscan);
-        this.escan = new Etherscan(
+        this.etherscan = new Etherscan(
             process.env.ETHERSCAN ?? "",
             this.apiURL,
             this.browserURL
@@ -31,7 +31,7 @@ export class ContractVerifier {
         let verified = false;
 
         if (this.isEtherscan) {
-            verified = await this.escan.isVerified(this.contractAddress);
+            verified = await this.etherscan.isVerified(this.contractAddress);
         }
         if (!verified) {
             verified = await isVerifiedOnBlockscout(
@@ -41,7 +41,7 @@ export class ContractVerifier {
         }
         if (verified) {
             console.log(
-                `${this.contractName} is already verified on: ${this.escan.getContractUrl(
+                `${this.contractName} is already verified on: ${this.etherscan.getContractUrl(
                     this.contractAddress
                 )}`
             );
@@ -55,7 +55,7 @@ export class ContractVerifier {
         compilerVersion: string;
     }): Promise<string | null> {
         try {
-            const res = await this.escan.verify(
+            const res = await this.etherscan.verify(
                 this.contractAddress,
                 params.solcInputJson,
                 params.fullContractName,
@@ -74,7 +74,7 @@ export class ContractVerifier {
     }
 
     private async checkVerificationStatus(guid: string): Promise<boolean> {
-        const status = await this.escan.getVerificationStatus(guid);
+        const status = await this.etherscan.getVerificationStatus(guid);
 
         if (status.isFailure()) {
             console.log(
@@ -84,7 +84,7 @@ export class ContractVerifier {
         }
 
         console.log(
-            `${this.contractName} is successfully verified on: ${this.escan.getContractUrl(
+            `${this.contractName} is successfully verified on: ${this.etherscan.getContractUrl(
                 this.contractAddress
             )}`
         );

--- a/src/upgrader.ts
+++ b/src/upgrader.ts
@@ -148,8 +148,7 @@ export abstract class Upgrader {
             console.log("Start verification");
             await Promise.all(contractsToUpgrade.map((contract) => verify(
                 contract.name,
-                contract.implementationAddress,
-                []
+                contract.implementationAddress
             )));
         }
     }

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -1,6 +1,6 @@
 import {artifacts, ethers, network} from "hardhat";
 import {ChainConfig} from "@nomicfoundation/hardhat-verify/types";
-import {Etherscan} from "@nomicfoundation/hardhat-verify/etherscan";
+import {ContractVerifier} from "./contractVerifier";
 import {
     builtinChains
 } from "@nomicfoundation/hardhat-verify/internal/chain-config";
@@ -12,7 +12,7 @@ import proxyBuildInfo from "@openzeppelin/upgrades-core/artifacts/build-info-v5.
 
 const RETRIES_AMOUNT = 5;
 
-interface VerificationTarget {
+export interface VerificationTarget {
     contractName: string;
     contractAddress: string;
     explorerUrls: {
@@ -79,9 +79,9 @@ const pingExplorer = async (baseUrl: string): Promise<boolean> => {
 
 const parseEndpoint = (endpoint: string) => {
     const {host, pathname} = new URL(endpoint);
-    const schain = pathname.split("/").filter(Boolean).pop()!;
+    const schainName = pathname.split("/").filter(Boolean).pop()!;
 
-    let networkType: keyof typeof BASE_EXPLORER_URLS;
+    let networkType: keyof typeof BASE_EXPLORER_URLS = "mainnet";
     if (host.includes("mainnet.")) {
         networkType = "mainnet";
     } else if (host.includes("testnet.")) {
@@ -91,32 +91,36 @@ const parseEndpoint = (endpoint: string) => {
     } else {
         throw new Error(`Unknown network in ENDPOINT: ${endpoint}`);
     }
-    return {networkType, schain};
+    return {networkType, schainName};
 }
 
-const getExplorerUrls = async (chainConfig?: ChainConfig) => {
-    if (process.env.EXPLORER_URL) {
-        const browserURL = process.env.EXPLORER_URL;
-        const apiURL = `${browserURL}/api`;
-        return {apiURL, browserURL};
-    }
-    if (chainConfig) {
-        return chainConfig.urls;
-    }
-    const endpoint = process.env.ENDPOINT;
-    if (!endpoint) {
+const getSchainExplorerUrls = async () => {
+    if (!process.env.ENDPOINT) {
         throw new Error("ENDPOINT is not set");
     }
-    const {schain, networkType} = parseEndpoint(endpoint);
-    const browserURL = `https://${schain}.${BASE_EXPLORER_URLS[networkType]}`;
+    const {schainName, networkType} = parseEndpoint(process.env.ENDPOINT);
+    const browserURL = `https://${schainName}.${BASE_EXPLORER_URLS[networkType]}`;
     const apiURL = `${browserURL}/api`;
-    if (!(await pingExplorer(browserURL))) {
+    if (!await pingExplorer(browserURL)) {
         throw new Error(`Explorer is not reachable, set EXPLORER_URL`);
     }
     return {apiURL, browserURL};
 }
 
-const isVerifiedOnBlockscout = async (apiURL: string, address: string): Promise<boolean> => {
+const getExplorerUrls = async (chainConfig?: ChainConfig) => {
+    if (process.env.EXPLORER_URL) {
+        return {
+            apiURL: `${process.env.EXPLORER_URL}/api`,
+            browserURL: process.env.EXPLORER_URL
+        };
+    }
+    if (chainConfig) {
+        return chainConfig.urls;
+    }
+    return await getSchainExplorerUrls();
+}
+
+export const isVerifiedOnBlockscout = async (apiURL: string, address: string): Promise<boolean> => {
     const url = `${apiURL}/v2/smart-contracts/${address}`;
     try {
         const response = await fetch(url);
@@ -127,81 +131,34 @@ const isVerifiedOnBlockscout = async (apiURL: string, address: string): Promise<
     }
 };
 
-const getVerifyParameters = async (contractName: string) => {
-    let fullContractName: string;
-    let compilerVersion: string;
-    let solcInputJson: string;
+export const getVerifyParameters = async (contractName: string) => {
     if (contractName === "TransparentUpgradeableProxy") {
-        fullContractName = `${proxyArtifact.sourceName}:${contractName}`;
-        compilerVersion = proxyBuildInfo.solcLongVersion;
-        solcInputJson = JSON.stringify(proxyBuildInfo.input);
-    } else {
-        const artifact = await artifacts.readArtifact(contractName);
-        fullContractName = `${artifact.sourceName}:${contractName}`;
-        const buildinfo = await artifacts.getBuildInfo(fullContractName);
-        if (!buildinfo) {
-            throw new Error(`No build-info for ${contractName}`);
-        }
-        compilerVersion = buildinfo.solcLongVersion;
-        solcInputJson = JSON.stringify(buildinfo.input);
+        return {
+            compilerVersion: proxyBuildInfo.solcLongVersion,
+            fullContractName: `${proxyArtifact.sourceName}:${contractName}`,
+            solcInputJson: JSON.stringify(proxyBuildInfo.input)
+        };
+    }
+    const artifact = await artifacts.readArtifact(contractName);
+    const fullContractName = `${artifact.sourceName}:${contractName}`;
+    const buildInfo = await artifacts.getBuildInfo(fullContractName);
+    if (!buildInfo) {
+        throw new Error(`No build-info for ${contractName}`);
     }
     return {
-        compilerVersion,
+        compilerVersion: buildInfo.solcLongVersion,
         fullContractName,
-        solcInputJson
-    }
+        solcInputJson: JSON.stringify(buildInfo.input)
+    };
 }
-
-const verificationAttempt = async (verificationTarget: VerificationTarget) => {
-    const {contractName, contractAddress, explorerUrls, isEtherscan} = verificationTarget;
-    const {browserURL, apiURL} = explorerUrls;
-    const escan = new Etherscan(
-        process.env.ETHERSCAN || "",
-        apiURL,
-        browserURL,
-    );
-    const {fullContractName, compilerVersion, solcInputJson} = await getVerifyParameters(contractName);
-    const isVerifiedOnEtherscan = isEtherscan && await escan.isVerified(contractAddress);
-    if (isVerifiedOnEtherscan || await isVerifiedOnBlockscout(apiURL, contractAddress)) {
-        const contractURL = escan.getContractUrl(contractAddress);
-        console.log(
-            `${contractName} is already verified on: ${contractURL}`
-        );
-        return true;
-    }
-    let guid: string;
-    try {
-        const result = await escan.verify(
-            contractAddress,
-            solcInputJson,
-            fullContractName,
-            compilerVersion,
-            "0x"
-        );
-        guid = result.message;
-    } catch (error) {
-        console.log(chalk.yellow(`Verification attempt for ${contractName} failed with error: ${error}`));
-        return false;
-    }
-    const verificationStatus = await escan.getVerificationStatus(guid);
-    if (verificationStatus.isFailure()) {
-        const errorMessage = `Failed to verify contract ${contractName}`;
-        console.log(chalk.red(errorMessage));
-        return false;
-    }
-    const contractURL = escan.getContractUrl(contractAddress);
-    console.log(
-        `${contractName} is successfully verified on: ${contractURL}`
-    );
-    return true;
-};
 
 const verifyWithRetry = async (
     verificationTarget: VerificationTarget,
     attempts: number
 ) => {
     if (attempts) {
-        if (!await verificationAttempt(verificationTarget)) {
+        const verifier = new ContractVerifier(verificationTarget);
+        if (!await verifier.attempt()) {
             const failedAttempts = 1;
             await verifyWithRetry(
                 verificationTarget,
@@ -211,62 +168,80 @@ const verifyWithRetry = async (
     }
 };
 
-export const verify = async (
+const verifyOnEtherscan = async (
+    contractName: string,
+    contractAddress: string,
+    chainConfig: ChainConfig
+) => {
+    if (!process.env.ETHERSCAN) {
+        console.log(
+            chalk.yellow(
+                `No etherscan API key provided. Skipping verification for ${contractName}.`
+            )
+        );
+        return;
+    }
+    const explorerUrls = await getExplorerUrls(chainConfig);
+    await verifyWithRetry(
+        {
+            contractAddress,
+            contractName,
+            explorerUrls,
+            isEtherscan: true
+        },
+        RETRIES_AMOUNT
+    );
+}
+
+const verifyOnBlockscout = async (
+    contractName: string,
+    contractAddress: string,
+    chainConfig: ChainConfig
+) => {
+    const explorerUrls = await getExplorerUrls(chainConfig);
+    await verifyWithRetry(
+        {
+            contractAddress,
+            contractName,
+            explorerUrls
+        },
+        RETRIES_AMOUNT
+    );
+}
+
+const verifyOnSkale = async (
     contractName: string,
     contractAddress: string
 ) => {
+    const explorerUrls = await getExplorerUrls();
+    await verifyWithRetry(
+        {
+            contractAddress,
+            contractName,
+            explorerUrls
+        },
+        RETRIES_AMOUNT
+    );
+}
+
+export const verify = async (contractName: string, contractAddress: string) => {
     const {chainId} = await ethers.provider.getNetwork();
-    const etherscanChainConfig = builtinChains.find((chain) => chain.chainId === Number(chainId));
-    const blockscoutChainConfig = blockscoutChains.find((chain) => chain.chainId === Number(chainId));
-    const isSkaleChain = !etherscanChainConfig && !blockscoutChainConfig;
-    if (etherscanChainConfig) {
-        if (process.env.ETHERSCAN) {
-            const explorerUrls = await getExplorerUrls(etherscanChainConfig);
-            await verifyWithRetry(
-                {
-                    contractAddress,
-                    contractName,
-                    explorerUrls,
-                    isEtherscan: true
-                },
-                RETRIES_AMOUNT
-            );
-        } else {
-            console.log(
-                chalk.yellow(
-                    `No etherscan API key provided. Skipping verification for ${contractName} on Etherscan.`
-                )
-            );
-        }
+    const etherscanConfig = builtinChains.find(config => config.chainId === Number(chainId));
+    const blockscoutConfig = blockscoutChains.find(config => config.chainId === Number(chainId));
+    const isSkaleChain = !etherscanConfig && !blockscoutConfig;
+
+    if (etherscanConfig) {
+        await verifyOnEtherscan(contractName, contractAddress, etherscanConfig);
     }
-    if (blockscoutChainConfig) {
-        const explorerUrls = await getExplorerUrls(blockscoutChainConfig);
-        await verifyWithRetry(
-            {
-                contractAddress,
-                contractName,
-                explorerUrls
-            },
-            RETRIES_AMOUNT
-        );
+    if (blockscoutConfig) {
+        await verifyOnBlockscout(contractName, contractAddress, blockscoutConfig);
     }
     if (isSkaleChain) {
-        const explorerUrls = await getExplorerUrls();
-        await verifyWithRetry(
-            {
-                contractAddress,
-                contractName,
-                explorerUrls
-            },
-            RETRIES_AMOUNT
-        );
+        await verifyOnSkale(contractName, contractAddress);
     }
 };
 
-export const verifyProxy = async (
-    contractName: string,
-    proxyAddress: string
-) => {
+export const verifyProxy = async (contractName: string, proxyAddress: string) => {
     await verify(
         contractName,
         await getImplementationAddress(

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -1,72 +1,207 @@
-import {ethers, network, run} from "hardhat";
+import {artifacts, ethers, network} from "hardhat";
+import {ChainConfig} from "@nomicfoundation/hardhat-verify/types";
+import {Etherscan} from "@nomicfoundation/hardhat-verify/etherscan";
 import {
     builtinChains
 } from "@nomicfoundation/hardhat-verify/internal/chain-config";
 import chalk from "chalk";
 import {getImplementationAddress} from "@openzeppelin/upgrades-core";
+import proxyArtifact from
+"@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts-v5/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json";
+import proxyBuildInfo from "@openzeppelin/upgrades-core/artifacts/build-info-v5.json";
 
 const RETRIES_AMOUNT = 5;
-
-const processError = (error: unknown, contractName: string) => {
-    if (error instanceof Error) {
-        const alreadyVerifiedErrorLine =
-            "Contract source code already verified";
-        if (error.toString().includes(alreadyVerifiedErrorLine)) {
-            const infoMessage = `${contractName} is already verified`;
-            console.log(chalk.grey(infoMessage));
-            return;
-        }
-        const errorMessage =
-            `Contract ${contractName} was not verified on etherscan`;
-        console.log(chalk.red(errorMessage));
-        console.log(error.toString());
-    } else {
-        console.log(
-            "Unknown exception type:",
-            error
-        );
-    }
-};
-
-const verificationAttempt = async (
-    contractName: string,
-    contractAddress: string,
-    constructorArguments: object
-) => {
-    try {
-        await run(
-            "verify:verify",
-            {
-                "address": contractAddress,
-                constructorArguments
-            }
-        );
-        return true;
-    } catch (error) {
-        processError(
-            error,
-            contractName
-        );
-    }
-    return false;
-};
 
 interface VerificationTarget {
     contractName: string;
     contractAddress: string;
-    constructorArguments: object;
+    explorerUrls: {
+        browserURL: string;
+        apiURL: string;
+    }
+    isEtherscan?: boolean;
 }
+
+const BASE_EXPLORER_URLS = {
+    legacy: "legacy-explorer.skalenodes.com",
+    mainnet: "explorer.mainnet.skalenodes.com",
+    testnet: "explorer.testnet.skalenodes.com"
+};
+
+const blockscoutChains: ChainConfig[] = [
+    {
+        chainId: 1,
+        network: "mainnet",
+        urls: {
+            apiURL: "https://eth.blockscout.com/api",
+            browserURL: "https://eth.blockscout.com",
+        }
+    },
+    {
+        chainId: 11155111,
+        network: "sepolia",
+        urls: {
+            apiURL: "https://eth-sepolia.blockscout.com/api",
+            browserURL: "https://eth-sepolia.blockscout.com",
+        }
+    },
+    {
+        chainId: 17000,
+        network: "holesky",
+        urls: {
+            apiURL: "https://eth-holesky.blockscout.com/api",
+            browserURL: "https://eth-holesky.blockscout.com",
+        }
+    },
+    {
+        chainId: 560048,
+        network: "hoodi",
+        urls: {
+            apiURL: "https://eth-hoodi.blockscout.com/api",
+            browserURL: "https://eth-hoodi.blockscout.com",
+        }
+    }
+]
+
+const pingExplorer = async (baseUrl: string): Promise<boolean> => {
+    const url = `${baseUrl}/api/health`;
+    try {
+        const res = await fetch(url);
+        if (!res.ok) {
+            return false;
+        }
+        const jsonResponse = await res.json();
+        return jsonResponse.healthy;
+    } catch {
+        return false;
+    }
+};
+
+const parseEndpoint = (endpoint: string) => {
+    const {host, pathname} = new URL(endpoint);
+    const schain = pathname.split("/").filter(Boolean).pop()!;
+
+    let networkType: keyof typeof BASE_EXPLORER_URLS;
+    if (host.includes("mainnet.")) {
+        networkType = "mainnet";
+    } else if (host.includes("testnet.")) {
+        networkType = "testnet";
+    } else if (host.includes("legacy-proxy.")) {
+        networkType = "legacy";
+    } else {
+        throw new Error(`Unknown network in ENDPOINT: ${endpoint}`);
+    }
+    return {networkType, schain};
+}
+
+const getExplorerUrls = async (chainConfig?: ChainConfig) => {
+    if (process.env.EXPLORER_URL) {
+        const browserURL = process.env.EXPLORER_URL;
+        const apiURL = `${browserURL}/api`;
+        return {apiURL, browserURL};
+    }
+    if (chainConfig) {
+        return chainConfig.urls;
+    }
+    const endpoint = process.env.ENDPOINT;
+    if (!endpoint) {
+        throw new Error("ENDPOINT is not set");
+    }
+    const {schain, networkType} = parseEndpoint(endpoint);
+    const browserURL = `https://${schain}.${BASE_EXPLORER_URLS[networkType]}`;
+    const apiURL = `${browserURL}/api`;
+    if (!(await pingExplorer(browserURL))) {
+        throw new Error(`Explorer is not reachable, set EXPLORER_URL`);
+    }
+    return {apiURL, browserURL};
+}
+
+const isVerifiedOnBlockscout = async (apiURL: string, address: string): Promise<boolean> => {
+    const url = `${apiURL}/v2/smart-contracts/${address}`;
+    try {
+        const response = await fetch(url);
+        const data = await response.json();
+        return data?.is_verified;
+    } catch {
+        return false;
+    }
+};
+
+const getVerifyParameters = async (contractName: string) => {
+    let fullContractName: string;
+    let compilerVersion: string;
+    let solcInputJson: string;
+    if (contractName === "TransparentUpgradeableProxy") {
+        fullContractName = `${proxyArtifact.sourceName}:${contractName}`;
+        compilerVersion = proxyBuildInfo.solcLongVersion;
+        solcInputJson = JSON.stringify(proxyBuildInfo.input);
+    } else {
+        const artifact = await artifacts.readArtifact(contractName);
+        fullContractName = `${artifact.sourceName}:${contractName}`;
+        const buildinfo = await artifacts.getBuildInfo(fullContractName);
+        if (!buildinfo) {
+            throw new Error(`No build-info for ${contractName}`);
+        }
+        compilerVersion = buildinfo.solcLongVersion;
+        solcInputJson = JSON.stringify(buildinfo.input);
+    }
+    return {
+        compilerVersion,
+        fullContractName,
+        solcInputJson
+    }
+}
+
+const verificationAttempt = async (verificationTarget: VerificationTarget) => {
+    const {contractName, contractAddress, explorerUrls, isEtherscan} = verificationTarget;
+    const {browserURL, apiURL} = explorerUrls;
+    const escan = new Etherscan(
+        process.env.ETHERSCAN || "",
+        apiURL,
+        browserURL,
+    );
+    const {fullContractName, compilerVersion, solcInputJson} = await getVerifyParameters(contractName);
+    const isVerifiedOnEtherscan = isEtherscan && await escan.isVerified(contractAddress);
+    if (isVerifiedOnEtherscan || await isVerifiedOnBlockscout(apiURL, contractAddress)) {
+        const contractURL = escan.getContractUrl(contractAddress);
+        console.log(
+            `${contractName} is already verified on: ${contractURL}`
+        );
+        return true;
+    }
+    let guid: string;
+    try {
+        const result = await escan.verify(
+            contractAddress,
+            solcInputJson,
+            fullContractName,
+            compilerVersion,
+            "0x"
+        );
+        guid = result.message;
+    } catch (error) {
+        console.log(chalk.yellow(`Verification attempt for ${contractName} failed with error: ${error}`));
+        return false;
+    }
+    const verificationStatus = await escan.getVerificationStatus(guid);
+    if (verificationStatus.isFailure()) {
+        const errorMessage = `Failed to verify contract ${contractName}`;
+        console.log(chalk.red(errorMessage));
+        return false;
+    }
+    const contractURL = escan.getContractUrl(contractAddress);
+    console.log(
+        `${contractName} is successfully verified on: ${contractURL}`
+    );
+    return true;
+};
 
 const verifyWithRetry = async (
     verificationTarget: VerificationTarget,
     attempts: number
 ) => {
     if (attempts) {
-        if (!await verificationAttempt(
-            verificationTarget.contractName,
-            verificationTarget.contractAddress,
-            verificationTarget.constructorArguments
-        )) {
+        if (!await verificationAttempt(verificationTarget)) {
             const failedAttempts = 1;
             await verifyWithRetry(
                 verificationTarget,
@@ -78,36 +213,66 @@ const verifyWithRetry = async (
 
 export const verify = async (
     contractName: string,
-    contractAddress: string,
-    constructorArguments: object
+    contractAddress: string
 ) => {
     const {chainId} = await ethers.provider.getNetwork();
-    if (!builtinChains.map((chain) => chain.chainId).includes(Number(chainId))) {
-        const errorMessage = "Verification on this network is not supported";
-        console.log(chalk.grey(errorMessage));
-        return;
+    const etherscanChainConfig = builtinChains.find((chain) => chain.chainId === Number(chainId));
+    const blockscoutChainConfig = blockscoutChains.find((chain) => chain.chainId === Number(chainId));
+    const isSkaleChain = !etherscanChainConfig && !blockscoutChainConfig;
+    if (etherscanChainConfig) {
+        if (process.env.ETHERSCAN) {
+            const explorerUrls = await getExplorerUrls(etherscanChainConfig);
+            await verifyWithRetry(
+                {
+                    contractAddress,
+                    contractName,
+                    explorerUrls,
+                    isEtherscan: true
+                },
+                RETRIES_AMOUNT
+            );
+        } else {
+            console.log(
+                chalk.yellow(
+                    `No etherscan API key provided. Skipping verification for ${contractName} on Etherscan.`
+                )
+            );
+        }
     }
-    await verifyWithRetry(
-        {
-            constructorArguments,
-            contractAddress,
-            contractName
-        },
-        RETRIES_AMOUNT
-    );
+    if (blockscoutChainConfig) {
+        const explorerUrls = await getExplorerUrls(blockscoutChainConfig);
+        await verifyWithRetry(
+            {
+                contractAddress,
+                contractName,
+                explorerUrls
+            },
+            RETRIES_AMOUNT
+        );
+    }
+    if (isSkaleChain) {
+        const explorerUrls = await getExplorerUrls();
+        await verifyWithRetry(
+            {
+                contractAddress,
+                contractName,
+                explorerUrls
+            },
+            RETRIES_AMOUNT
+        );
+    }
 };
 
 export const verifyProxy = async (
     contractName: string,
-    proxyAddress: string,
-    constructorArguments: object
+    proxyAddress: string
 ) => {
     await verify(
         contractName,
         await getImplementationAddress(
             network.provider,
             proxyAddress
-        ),
-        constructorArguments
+        )
     );
+    await verify("TransparentUpgradeableProxy", proxyAddress);
 };

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -10,6 +10,8 @@ import proxyArtifact from
 "@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts-v5/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json";
 import proxyBuildInfo from "@openzeppelin/upgrades-core/artifacts/build-info-v5.json";
 
+// cspell:words skalenodes holesky hoodi
+
 const RETRIES_AMOUNT = 5;
 
 export interface VerificationTarget {

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -10,7 +10,7 @@ import proxyArtifact from
 "@openzeppelin/upgrades-core/artifacts/@openzeppelin/contracts-v5/proxy/transparent/TransparentUpgradeableProxy.sol/TransparentUpgradeableProxy.json";
 import proxyBuildInfo from "@openzeppelin/upgrades-core/artifacts/build-info-v5.json";
 
-// cspell:words skalenodes holesky hoodi
+// Cspell:words skalenodes holesky hoodi
 
 const RETRIES_AMOUNT = 5;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
       "declaration": true,
       "outDir": "./dist",
       "sourceMap": true,
+      "resolveJsonModule": true,
       "target": "ES2020"
   },
   "include": ["./src", "./typechain-types"],


### PR DESCRIPTION
The provided changes enable contract verification on both Etherscan and Blockscout. For Ethereum mainnet or testnets, contracts will be verified on both explorers. To verify on Etherscan, you must set the ETHERSCAN environment variable; for Blockscout, no additional configuration is required. When deploying to a SKALE chain, contracts will be verified only on Blockscout.

New envs:
- EXPLORER_URL – custom blockscout url (optional)

Closes #408 