### PR TITLE
refactor submitter to move atomicity warning to upgrader side

### DIFF
--- a/src/submitters/auto-submitter.ts
+++ b/src/submitters/auto-submitter.ts
@@ -52,6 +52,7 @@ export class AutoSubmitter extends Submitter {
         const owner = await this.upgrader.getOwner();
         if (await ethers.provider.getCode(owner) === "0x") {
             console.log("Owner is not a contract");
+            Upgrader.atomicityWarning();
             return new EoaSubmitter();
         }
 

--- a/src/submitters/auto-submitter.ts
+++ b/src/submitters/auto-submitter.ts
@@ -52,20 +52,21 @@ export class AutoSubmitter extends Submitter {
         const owner = await this.upgrader.getOwner();
         if (await ethers.provider.getCode(owner) === "0x") {
             console.log("Owner is not a contract");
-            Upgrader.atomicityWarning();
+            this.upgrader.atomicityWarning();
             return new EoaSubmitter();
         }
 
         console.log("Owner is a contract");
-        return AutoSubmitter.getSubmitterForContractOwner(owner);
+        return this.getSubmitterForContractOwner(owner);
     }
 
-    private static async getSubmitterForContractOwner (owner: string) {
+    private async getSubmitterForContractOwner (owner: string) {
         const mainnetChainId = AutoSubmitter.getMainnetChainId();
         if (ethers.getAddress(owner) ===
             ethers.getAddress(MARIONETTE_ADDRESS)) {
             console.log("Marionette owner is detected");
 
+            this.upgrader.atomicityWarning();
             const imaInstance = await AutoSubmitter.getImaInstance();
             const safeAddress = AutoSubmitter.getSafeAddress();
             const schainHash = AutoSubmitter.getSchainHash();
@@ -107,7 +108,6 @@ export class AutoSubmitter extends Submitter {
 
         // Assuming owner is a Gnosis Safe
         console.log("Using Gnosis Safe");
-
         return new SafeSubmitter(owner, mainnetChainId);
     }
 

--- a/src/submitters/auto-submitter.ts
+++ b/src/submitters/auto-submitter.ts
@@ -15,7 +15,8 @@ import {skaleContracts} from "@skalenetwork/skale-contracts-ethers-v6";
 
 export class AutoSubmitter extends Submitter {
     name = "Auto Submitter";
-    upgrader: Upgrader
+    upgrader: Upgrader;
+    submitter: Submitter | undefined;
 
     constructor (
         upgrader: Upgrader
@@ -42,31 +43,40 @@ export class AutoSubmitter extends Submitter {
 
     async submit (transactions: Transaction[]) {
         console.log(`Submit via ${this.name}`);
-        const submitter = await this.getSubmitter();
-        await submitter.submit(transactions);
+        await this.loadSubmitter();
+        await this.submitter!.submit(transactions);
+    }
+
+    async isAtomicSubmitter(): Promise<boolean> {
+        await this.loadSubmitter();
+        return this.submitter!.isAtomicSubmitter();
     }
 
     // Private
+
+    private async loadSubmitter () {
+        if(!this.submitter) {
+            this.submitter = await this.getSubmitter();
+        }
+    }
 
     private async getSubmitter () {
         const owner = await this.upgrader.getOwner();
         if (await ethers.provider.getCode(owner) === "0x") {
             console.log("Owner is not a contract");
-            this.upgrader.atomicityWarning();
             return new EoaSubmitter();
         }
 
         console.log("Owner is a contract");
-        return this.getSubmitterForContractOwner(owner);
+        return AutoSubmitter.getSubmitterForContractOwner(owner);
     }
 
-    private async getSubmitterForContractOwner (owner: string) {
+    private static async getSubmitterForContractOwner (owner: string) {
         const mainnetChainId = AutoSubmitter.getMainnetChainId();
         if (ethers.getAddress(owner) ===
             ethers.getAddress(MARIONETTE_ADDRESS)) {
             console.log("Marionette owner is detected");
 
-            this.upgrader.atomicityWarning();
             const imaInstance = await AutoSubmitter.getImaInstance();
             const safeAddress = AutoSubmitter.getSafeAddress();
             const schainHash = AutoSubmitter.getSchainHash();

--- a/src/submitters/eoa-submitter.ts
+++ b/src/submitters/eoa-submitter.ts
@@ -7,7 +7,6 @@ export class EoaSubmitter extends Submitter {
     name = "EOA Submitter";
 
     async submit (transactions: Transaction[]) {
-        EoaSubmitter.atomicityWarning();
         const [deployer] = await ethers.getSigners();
         console.log(`Send transaction via ${this.name}`);
 

--- a/src/submitters/eoa-submitter.ts
+++ b/src/submitters/eoa-submitter.ts
@@ -5,6 +5,7 @@ import {ethers} from "hardhat";
 
 export class EoaSubmitter extends Submitter {
     name = "EOA Submitter";
+    protected atomicSubmitter = false;
 
     async submit (transactions: Transaction[]) {
         const [deployer] = await ethers.getSigners();
@@ -27,5 +28,9 @@ export class EoaSubmitter extends Submitter {
         }
 
         console.log("All transactions sent and confirmed");
+    }
+
+    public isAtomicSubmitter(): boolean {
+        return this.atomicSubmitter;
     }
 }

--- a/src/submitters/eoa-submitter.ts
+++ b/src/submitters/eoa-submitter.ts
@@ -5,7 +5,6 @@ import {ethers} from "hardhat";
 
 export class EoaSubmitter extends Submitter {
     name = "EOA Submitter";
-    protected atomicSubmitter = false;
 
     async submit (transactions: Transaction[]) {
         const [deployer] = await ethers.getSigners();
@@ -28,9 +27,5 @@ export class EoaSubmitter extends Submitter {
         }
 
         console.log("All transactions sent and confirmed");
-    }
-
-    public isAtomicSubmitter(): boolean {
-        return this.atomicSubmitter;
     }
 }

--- a/src/submitters/safe-ima-legacy-marionette-submitter.ts
+++ b/src/submitters/safe-ima-legacy-marionette-submitter.ts
@@ -5,7 +5,6 @@ import {ethers} from "hardhat";
 
 
 export class SafeImaLegacyMarionetteSubmitter extends SafeToImaSubmitter {
-    protected atomicSubmitter = false;
     marionette = new ethers.BaseContract(
         MARIONETTE_ADDRESS,
         new ethers.Interface([

--- a/src/submitters/safe-ima-legacy-marionette-submitter.ts
+++ b/src/submitters/safe-ima-legacy-marionette-submitter.ts
@@ -42,10 +42,6 @@ export class SafeImaLegacyMarionetteSubmitter extends SafeToImaSubmitter {
     ) as LegacyMarionette;
 
     async submit (transactions: Transaction[]): Promise<void> {
-        const singleTransaction = 1;
-        if (transactions.length > singleTransaction) {
-            SafeImaLegacyMarionetteSubmitter.atomicityWarning();
-        }
         const marionetteAddress = await this.marionette.getAddress();
         const transactionsToMarionette =
             (await Promise.all(transactions.

--- a/src/submitters/safe-ima-legacy-marionette-submitter.ts
+++ b/src/submitters/safe-ima-legacy-marionette-submitter.ts
@@ -5,6 +5,7 @@ import {ethers} from "hardhat";
 
 
 export class SafeImaLegacyMarionetteSubmitter extends SafeToImaSubmitter {
+    protected atomicSubmitter = false;
     marionette = new ethers.BaseContract(
         MARIONETTE_ADDRESS,
         new ethers.Interface([

--- a/src/submitters/safe-ima-marionette-submitter.ts
+++ b/src/submitters/safe-ima-marionette-submitter.ts
@@ -5,6 +5,7 @@ import {ethers} from "hardhat";
 
 
 export class SafeImaMarionetteSubmitter extends SafeToImaSubmitter {
+    protected atomicSubmitter = false;
     marionette = new ethers.BaseContract(
         MARIONETTE_ADDRESS,
         new ethers.Interface([

--- a/src/submitters/safe-submitter.ts
+++ b/src/submitters/safe-submitter.ts
@@ -7,6 +7,7 @@ import {ethers} from "hardhat";
 export class SafeSubmitter extends Submitter {
     name = "Safe Submitter";
     safeAddress: string;
+    protected atomicSubmitter = true;
 
     chainId: bigint | undefined;
 
@@ -25,5 +26,9 @@ export class SafeSubmitter extends Submitter {
             this.chainId,
             transactions
         );
+    }
+
+    public isAtomicSubmitter(): boolean {
+        return this.atomicSubmitter;
     }
 }

--- a/src/submitters/safe-submitter.ts
+++ b/src/submitters/safe-submitter.ts
@@ -5,6 +5,7 @@ import {ethers} from "hardhat";
 
 
 export class SafeSubmitter extends Submitter {
+    name = "Safe Submitter";
     safeAddress: string;
 
     chainId: bigint | undefined;

--- a/src/submitters/safe-submitter.ts
+++ b/src/submitters/safe-submitter.ts
@@ -15,6 +15,7 @@ export class SafeSubmitter extends Submitter {
         super();
         this.safeAddress = safeAddress;
         this.chainId = chainId;
+        this.atomicSubmitter = true;
     }
 
     async submit (transactions: Transaction[]): Promise<void> {
@@ -26,9 +27,5 @@ export class SafeSubmitter extends Submitter {
             this.chainId,
             transactions
         );
-    }
-
-    public isAtomicSubmitter(): boolean {
-        return this.atomicSubmitter;
     }
 }

--- a/src/submitters/safe-to-ima-submitter.ts
+++ b/src/submitters/safe-to-ima-submitter.ts
@@ -14,6 +14,7 @@ export class SafeToImaSubmitter extends SafeSubmitter {
 
     targetSchainHash: BytesLike;
 
+    protected atomicSubmitter = false;
     private messageProxyForMainnet: BaseContract | undefined;
 
     constructor (

--- a/src/submitters/safe-to-ima-submitter.ts
+++ b/src/submitters/safe-to-ima-submitter.ts
@@ -9,6 +9,7 @@ interface Network {
 }
 
 export class SafeToImaSubmitter extends SafeSubmitter {
+    name = "Safe to IMA Submitter";
     imaInstance: Instance;
 
     targetSchainHash: BytesLike;
@@ -29,10 +30,6 @@ export class SafeToImaSubmitter extends SafeSubmitter {
     }
 
     async submit (transactions: Transaction[]): Promise<void> {
-        const singleTransaction = 1;
-        if (transactions.length > singleTransaction) {
-            SafeToImaSubmitter.atomicityWarning();
-        }
         const messageProxyForMainnet = await this.getMessageProxyForMainnet();
         const messageProxyForMainnetAddress = await messageProxyForMainnet.getAddress();
         const transactionsToIma = transactions.map((transaction) => Transaction.from({
@@ -46,6 +43,7 @@ export class SafeToImaSubmitter extends SafeSubmitter {
             ),
             "to": messageProxyForMainnetAddress
         }));
+        // Althouth transactions are atomic on mainnet side, they are not atomic on schain side.
         await super.submit(transactionsToIma);
     }
 

--- a/src/submitters/safe-to-ima-submitter.ts
+++ b/src/submitters/safe-to-ima-submitter.ts
@@ -43,7 +43,7 @@ export class SafeToImaSubmitter extends SafeSubmitter {
             ),
             "to": messageProxyForMainnetAddress
         }));
-        // Althouth transactions are atomic on mainnet side, they are not atomic on schain side.
+        // Although transactions are atomic on mainnet side, they are not atomic on schain side.
         await super.submit(transactionsToIma);
     }
 

--- a/src/submitters/safe-to-ima-submitter.ts
+++ b/src/submitters/safe-to-ima-submitter.ts
@@ -13,8 +13,6 @@ export class SafeToImaSubmitter extends SafeSubmitter {
     imaInstance: Instance;
 
     targetSchainHash: BytesLike;
-
-    protected atomicSubmitter = false;
     private messageProxyForMainnet: BaseContract | undefined;
 
     constructor (
@@ -28,6 +26,8 @@ export class SafeToImaSubmitter extends SafeSubmitter {
         );
         this.imaInstance = imaInstance;
         this.targetSchainHash = network.targetSchainHash;
+        // After super call
+        this.atomicSubmitter = false;
     }
 
     async submit (transactions: Transaction[]): Promise<void> {

--- a/src/submitters/submitter.ts
+++ b/src/submitters/submitter.ts
@@ -1,7 +1,11 @@
 import {Transaction} from "ethers";
 
 export abstract class Submitter {
+    protected atomicSubmitter: boolean = false;
     abstract name: string;
     abstract submit(transactions: Transaction[]): Promise<void>;
-    abstract isAtomicSubmitter(): Promise<boolean> | boolean;
+
+    isAtomicSubmitter(): Promise<boolean> | boolean {
+        return this.atomicSubmitter;
+    }
 }

--- a/src/submitters/submitter.ts
+++ b/src/submitters/submitter.ts
@@ -1,22 +1,6 @@
-import {EXIT_CODES} from "../exitCodes";
 import {Transaction} from "ethers";
-import chalk from "chalk";
-
 
 export abstract class Submitter {
+    abstract name: string;
     abstract submit(transactions: Transaction[]): Promise<void>;
-
-    // Protected
-
-    protected static atomicityWarning () {
-        if (process.env.ALLOW_NOT_ATOMIC_UPGRADE) {
-            console.log(chalk.yellow("Not atomic upgrade is performing"));
-        } else {
-            console.log(chalk.red("The upgrade will consist" +
-                " of multiple transactions and will not be atomic"));
-            console.log(chalk.red("If not atomic upgrade is OK" +
-                " set ALLOW_NOT_ATOMIC_UPGRADE environment variable"));
-            process.exit(EXIT_CODES.NOT_ATOMIC_UPGRADE);
-        }
-    }
 }

--- a/src/submitters/submitter.ts
+++ b/src/submitters/submitter.ts
@@ -3,4 +3,5 @@ import {Transaction} from "ethers";
 export abstract class Submitter {
     abstract name: string;
     abstract submit(transactions: Transaction[]): Promise<void>;
+    abstract isAtomicSubmitter(): Promise<boolean> | boolean;
 }

--- a/src/upgrader.ts
+++ b/src/upgrader.ts
@@ -92,18 +92,6 @@ export abstract class Upgrader {
 
     // Public
 
-    public static atomicityWarning () {
-        if (process.env.ALLOW_NOT_ATOMIC_UPGRADE) {
-            console.log(chalk.yellow("Not atomic upgrade is performing"));
-        } else {
-            console.log(chalk.red("The upgrade will consist" +
-                " of multiple transactions and will not be atomic"));
-            console.log(chalk.red("If not atomic upgrade is OK" +
-                " set ALLOW_NOT_ATOMIC_UPGRADE environment variable"));
-            process.exit(EXIT_CODES.NOT_ATOMIC_UPGRADE);
-        }
-    }
-
     async upgrade () {
         const version = await this.prepareVersion();
         await this.callDeployNewContracts();
@@ -266,20 +254,35 @@ export abstract class Upgrader {
         }
     }
 
-    private verifySubmitter() {
-        /*
-         * Check safety of the upgrade
-         * Auto-Submitter has its own check
-         * Safe Submitter is always safe
-         * All the others right now are not fully atomic (including the ones that use IMA)
-         */
-        const maxNotAtomicTransactions = 1;
+    private verifySubmitter () {
+        if (this.submitter.name === "Auto Submitter") {
+            // AutoSubmitter performs its own atomicity check
+            return;
+        }
+        if (this.submitter.name === "Safe Submitter") {
+            // SafeSubmitter always provides atomicity
+            return;
+        }
+        this.atomicityWarning();
+    }
+
+    // Call only if submitter is NOT SafeSubmitter
+    public atomicityWarning () {
+        const maxTransactionsForAtomicUpgrade = 1;
         if (
-            this.submitter.name !== "Safe Submitter" &&
-            this.submitter.name !== "Auto Submitter" &&
-            this.transactions.length > maxNotAtomicTransactions
+            this.transactions.length <= maxTransactionsForAtomicUpgrade
         ) {
-            Upgrader.atomicityWarning();
+            // Safe
+            return;
+        }
+        if (process.env.ALLOW_NOT_ATOMIC_UPGRADE) {
+            console.log(chalk.yellow("Not atomic upgrade is performing"));
+        } else {
+            console.log(chalk.red("The upgrade will consist" +
+                " of multiple transactions and will not be atomic"));
+            console.log(chalk.red("If not atomic upgrade is OK" +
+                " set ALLOW_NOT_ATOMIC_UPGRADE environment variable"));
+            process.exit(EXIT_CODES.NOT_ATOMIC_UPGRADE);
         }
     }
 }

--- a/src/upgrader.ts
+++ b/src/upgrader.ts
@@ -100,7 +100,7 @@ export abstract class Upgrader {
         // Write version
         await this.setVersion(version);
         await this.writeTransactions(version);
-        this.verifySubmitter();
+        await this.verifySubmitter();
         await this.submitter.submit(this.transactions);
         await this.verify();
         console.log("Done");
@@ -254,35 +254,24 @@ export abstract class Upgrader {
         }
     }
 
-    private verifySubmitter () {
-        if (this.submitter.name === "Auto Submitter") {
-            // AutoSubmitter performs its own atomicity check
-            return;
-        }
-        if (this.submitter.name === "Safe Submitter") {
-            // SafeSubmitter always provides atomicity
-            return;
-        }
-        this.atomicityWarning();
-    }
-
-    // Call only if submitter is NOT SafeSubmitter
-    public atomicityWarning () {
+    private async verifySubmitter () {
         const maxTransactionsForAtomicUpgrade = 1;
         if (
-            this.transactions.length <= maxTransactionsForAtomicUpgrade
+            this.transactions.length <= maxTransactionsForAtomicUpgrade ||
+            await this.submitter.isAtomicSubmitter()
         ) {
-            // Safe
+            console.log(chalk.yellow("Atomic upgrade is performing."));
             return;
         }
+
         if (process.env.ALLOW_NOT_ATOMIC_UPGRADE) {
-            console.log(chalk.yellow("Not atomic upgrade is performing"));
-        } else {
-            console.log(chalk.red("The upgrade will consist" +
-                " of multiple transactions and will not be atomic"));
-            console.log(chalk.red("If not atomic upgrade is OK" +
-                " set ALLOW_NOT_ATOMIC_UPGRADE environment variable"));
-            process.exit(EXIT_CODES.NOT_ATOMIC_UPGRADE);
+            console.log(chalk.yellow("Not atomic upgrade is performing."));
+            return;
         }
+        console.log(chalk.red("The upgrade will consist" +
+            " of multiple transactions and will not be atomic"));
+        console.log(chalk.red("If not atomic upgrade is OK" +
+            " set ALLOW_NOT_ATOMIC_UPGRADE environment variable"));
+        process.exit(EXIT_CODES.NOT_ATOMIC_UPGRADE);
     }
 }

--- a/src/upgrader.ts
+++ b/src/upgrader.ts
@@ -92,6 +92,18 @@ export abstract class Upgrader {
 
     // Public
 
+    public static atomicityWarning () {
+        if (process.env.ALLOW_NOT_ATOMIC_UPGRADE) {
+            console.log(chalk.yellow("Not atomic upgrade is performing"));
+        } else {
+            console.log(chalk.red("The upgrade will consist" +
+                " of multiple transactions and will not be atomic"));
+            console.log(chalk.red("If not atomic upgrade is OK" +
+                " set ALLOW_NOT_ATOMIC_UPGRADE environment variable"));
+            process.exit(EXIT_CODES.NOT_ATOMIC_UPGRADE);
+        }
+    }
+
     async upgrade () {
         const version = await this.prepareVersion();
         await this.callDeployNewContracts();
@@ -100,6 +112,7 @@ export abstract class Upgrader {
         // Write version
         await this.setVersion(version);
         await this.writeTransactions(version);
+        this.verifySubmitter();
         await this.submitter.submit(this.transactions);
         await this.verify();
         console.log("Done");
@@ -250,6 +263,13 @@ export abstract class Upgrader {
             const cannotCheckMessage =
                 `Can't check currently deployed version of ${this.projectName}`;
             console.log(chalk.yellow(cannotCheckMessage));
+        }
+    }
+
+    private verifySubmitter() {
+        const maxNotAtomicTransactions = 1;
+        if (this.submitter.name !== "Safe Submitter" && this.transactions.length > maxNotAtomicTransactions) {
+            Upgrader.atomicityWarning();
         }
     }
 }

--- a/src/upgrader.ts
+++ b/src/upgrader.ts
@@ -267,8 +267,18 @@ export abstract class Upgrader {
     }
 
     private verifySubmitter() {
+        /*
+         * Check safety of the upgrade
+         * Auto-Submitter has its own check
+         * Safe Submitter is always safe
+         * All the others right now are not fully atomic (including the ones that use IMA)
+         */
         const maxNotAtomicTransactions = 1;
-        if (this.submitter.name !== "Safe Submitter" && this.transactions.length > maxNotAtomicTransactions) {
+        if (
+            this.submitter.name !== "Safe Submitter" &&
+            this.submitter.name !== "Auto Submitter" &&
+            this.transactions.length > maxNotAtomicTransactions
+        ) {
             Upgrader.atomicityWarning();
         }
     }


### PR DESCRIPTION
Moving atomicity warning to upgrader and AutoSubmitter.

Fixes https://github.com/skalenetwork/upgrade-tools/issues/433