### PR TITLE
Fix nonces and proxies initialization

### DIFF
--- a/src/nonceProvider.ts
+++ b/src/nonceProvider.ts
@@ -19,7 +19,7 @@ export class NonceProvider {
             this.currentNonce += 1;
             return nonce;
         }
-        return this.releasedNonces.shift();
+        return this.releasedNonces.shift()!;
     }
 
     releaseNonce (nonce: number) {

--- a/src/proxyUpgrader.ts
+++ b/src/proxyUpgrader.ts
@@ -105,7 +105,7 @@ export abstract class ProxyUpgrader {
     }
 
     private async resolveDeployment(response: DeployImplementationResponse, nonce?: number): Promise<string> {
-        if (nonce && (isAddress(response) || response.nonce < nonce)) {
+        if (typeof nonce !== "undefined" && (isAddress(response) || response.nonce < nonce)) {
             this.nonceProvider?.releaseNonce(nonce);
         }
 

--- a/src/proxyUpgrader.ts
+++ b/src/proxyUpgrader.ts
@@ -105,13 +105,14 @@ export abstract class ProxyUpgrader {
     }
 
     private async resolveDeployment(response: DeployImplementationResponse, nonce?: number): Promise<string> {
-        // If return is valid address, means no deployment transaction was required
+        if (nonce && (isAddress(response) || response.nonce < nonce)) {
+            this.nonceProvider?.releaseNonce(nonce);
+        }
+
         if (isAddress(response)) {
-            if (nonce) {
-                this.nonceProvider?.releaseNonce(nonce);
-            }
             return response;
         }
+
         const receipt = await response.wait();
         if(!receipt) {
             throw new Error(`Failed to get receipt for deployment transaction`);

--- a/src/upgrader.ts
+++ b/src/upgrader.ts
@@ -94,8 +94,8 @@ export abstract class Upgrader {
 
     async upgrade () {
         const version = await this.prepareVersion();
-        await this.callDeployNewContracts();
         await this.upgradeOldContracts();
+        await this.callDeployNewContracts();
         await this.callInitialize();
         // Write version
         await this.setVersion(version);


### PR DESCRIPTION
- proxy upgraders were not initialized during new contracts deployment what prevented getting of the upgrade owner
- upgrades.prepareUpgrade sometimes returns old transaction instead of address in case the implementation is up to date